### PR TITLE
Restart haproxy unless stopped

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -464,6 +464,7 @@ services:
   haproxy:
     build: mod/haproxy
     image: alangecker/bbb-haproxy:2.8.10
+    restart: unless-stopped
     volumes:
       - ./data/haproxy/letsencrypt:/etc/letsencrypt
       - ./mod/haproxy/haproxy.cfg:/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
Every service is defined to restart unless stopped but this appears to be forgotten with the haproxy.